### PR TITLE
Bug fix & tests added: 3 SimDemo.m files were broken by d219623 due to change in location of loaded *.mat files

### DIFF
--- a/Models_Functions/SIRFSEfun/SimDemo_SIRFSE.m
+++ b/Models_Functions/SIRFSEfun/SimDemo_SIRFSE.m
@@ -1,8 +1,8 @@
 %% Settings
-clear; clc;
-Sim    =  load('SIRFSE/Parameters/DefaultSim.mat');    % load default simulation parameters
-Prot   =  load('SIRFSE/Parameters/DefaultProt.mat');   % load default protocol
-FitOpt =  load('SIRFSE/Parameters/DefaultFitOpt.mat'); % load default fit options
+clc;
+Sim    =  load('SIRFSEfun/Parameters/DefaultSim.mat');    % load default simulation parameters
+Prot   =  load('SIRFSEfun/Parameters/DefaultProt.mat');   % load default protocol
+FitOpt =  load('SIRFSEfun/Parameters/DefaultFitOpt.mat'); % load default fit options
 
 %% Simulation
 tic

--- a/Models_Functions/SPGRfun/SimDemo_SPGR.m
+++ b/Models_Functions/SPGRfun/SimDemo_SPGR.m
@@ -1,9 +1,9 @@
 %% Settings
 
 clc;
-Sim  = load('SPGR/Parameters/DefaultSim.mat');      % load default parameters
-Prot = load('SPGR/Parameters/DemoProtocol.mat');     % load default protocol
-FitOpt = load('SPGR/Parameters/DefaultFitOpt.mat');	% load default fit options
+Sim  = load('SPGRfun/Parameters/DefaultSim.mat');      % load default parameters
+Prot = load('SPGRfun/Parameters/DemoProtocol.mat');     % load default protocol
+FitOpt = load('SPGRfun/Parameters/DefaultFitOpt.mat');	% load default fit options
 FitOpt.R1 = computeR1obs(Sim.Param);
 %% Simulation
 

--- a/Models_Functions/bSSFPfun/SimDemo_bSSFP.m
+++ b/Models_Functions/bSSFPfun/SimDemo_bSSFP.m
@@ -1,8 +1,8 @@
 %% Settings
-clear; clc;
-Sim    = load('bSSFP/Parameters/DefaultSim.mat');    % load default parameters
-Prot   = load('bSSFP/Parameters/DefaultProt.mat');   % load default protocol
-FitOpt = load('bSSFP/Parameters/DefaultFitOpt.mat'); % load default fit options
+clc;
+Sim    = load('bSSFPfun/Parameters/DefaultSim.mat');    % load default parameters
+Prot   = load('bSSFPfun/Parameters/DefaultProt.mat');   % load default protocol
+FitOpt = load('bSSFPfun/Parameters/DefaultFitOpt.mat'); % load default fit options
 FitOpt.R1 = Sim.Param.R1f;                           % simulate R1 map value
 
 %% Simulation

--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ Current Test tags:
 
 * Unit
 
+* Integration
+
+* Demo
+
 * SPGR
+
+* bSSFP
+
+* SIRFSE
 
 ## Citation
 

--- a/Test/Models_Functions/SIRFSEfun/SimDemo_SIRFSE_Test.m
+++ b/Test/Models_Functions/SIRFSEfun/SimDemo_SIRFSE_Test.m
@@ -1,0 +1,38 @@
+classdef (TestTags = {'SIRFSE', 'Demo', 'Integration'}) SimDemo_SIRFSE_Test < matlab.unittest.TestCase
+
+    properties
+       qmrilabPath = cell2mat(regexp(cd, '.*qMRILab/', 'match'));
+    end
+    methods (TestClassSetup)
+        function addqMRILabToPath(testCase)
+            addpath(genpath(testCase.qmrilabPath));
+        end
+    end
+
+    methods (TestClassTeardown)
+        function removeqMRILabFromPath(testCase)
+            clear all, close all
+        end
+    end
+
+    methods (Test)
+        function testFittedParamsNearInputValues(testCase)
+            run([testCase.qmrilabPath, '/Models_Functions/SIRFSEfun/SimDemo_SIRFSE.m'])
+
+            inputParams  = Sim.Param;
+            outputParams = SimCurveResults;
+
+            inputArr  = [inputParams.F  inputParams.kf  inputParams.R1f  inputParams.R1r];
+            outputArr = [outputParams.F outputParams.kf outputParams.R1f outputParams.R1r];
+
+            %                                                 , # percent
+            %                                                 . [F  kf R1f R2r]
+            testCase.verifyLessThan(pDiff(inputArr, outputArr), [30 30 30 40]);
+        end
+    end
+
+end
+
+function value = pDiff(inputVal, outputVal)
+    value = abs((outputVal-inputVal)./inputVal).*100;
+end

--- a/Test/Models_Functions/SIRFSEfun/SimDemo_SIRFSE_Test.m
+++ b/Test/Models_Functions/SIRFSEfun/SimDemo_SIRFSE_Test.m
@@ -26,8 +26,8 @@ classdef (TestTags = {'SIRFSE', 'Demo', 'Integration'}) SimDemo_SIRFSE_Test < ma
             outputArr = [outputParams.F outputParams.kf outputParams.R1f outputParams.R1r];
 
             %                                                 , # percent
-            %                                                 . [F  kf R1f R2r]
-            testCase.verifyLessThan(pDiff(inputArr, outputArr), [30 30 30 40]);
+            %                                                 . [F  kf R1f R1r]
+            testCase.verifyLessThan(pDiff(inputArr, outputArr), [30 30 30 30]);
         end
     end
 

--- a/Test/Models_Functions/SPGRfun/SimDemo_SPGR_Test.m
+++ b/Test/Models_Functions/SPGRfun/SimDemo_SPGR_Test.m
@@ -1,0 +1,38 @@
+classdef (TestTags = {'SPGR', 'Demo', 'Integration'}) SimDemo_SPGR_Test < matlab.unittest.TestCase
+
+    properties
+       qmrilabPath = cell2mat(regexp(cd, '.*qMRILab/', 'match'));
+    end
+    methods (TestClassSetup)
+        function addqMRILabToPath(testCase)
+            addpath(genpath(testCase.qmrilabPath));
+        end
+    end
+
+    methods (TestClassTeardown)
+        function removeqMRILabFromPath(testCase)
+            clear all, close all
+        end
+    end
+
+    methods (Test)
+        function testFittedParamsNearInputValues(testCase)
+            run([testCase.qmrilabPath, '/Models_Functions/SPGRfun/SimDemo_SPGR.m'])
+
+            inputParams  = Sim.Param;
+            outputParams = SimCurveResults;
+
+            inputArr  = [inputParams.F  inputParams.kf  inputParams.R1f  inputParams.T2f  inputParams.T2r];
+            outputArr = [outputParams.F outputParams.kf outputParams.R1f outputParams.T2f outputParams.T2r];
+
+            %                                                 , # percent
+            %                                                 . [F  kf R1f T2f T2r]
+            testCase.verifyLessThan(pDiff(inputArr, outputArr), [30 30 30  30  30]);
+        end
+    end
+
+end
+
+function value = pDiff(inputVal, outputVal)
+    value = abs((outputVal-inputVal)./inputVal).*100;
+end

--- a/Test/Models_Functions/bSSFPfun/SimDemo_bSSFP_Test.m
+++ b/Test/Models_Functions/bSSFPfun/SimDemo_bSSFP_Test.m
@@ -1,0 +1,38 @@
+classdef (TestTags = {'bSSFP', 'Demo', 'Integration'}) SimDemo_bSSFP_Test < matlab.unittest.TestCase
+
+    properties
+       qmrilabPath = cell2mat(regexp(cd, '.*qMRILab/', 'match'));
+    end
+    methods (TestClassSetup)
+        function addqMRILabToPath(testCase)
+            addpath(genpath(testCase.qmrilabPath));
+        end
+    end
+
+    methods (TestClassTeardown)
+        function removeqMRILabFromPath(testCase)
+            clear all, close all
+        end
+    end
+
+    methods (Test)
+        function testFittedParamsNearInputValues(testCase)
+            run([testCase.qmrilabPath, '/Models_Functions/bSSFPfun/SimDemo_bSSFP.m'])
+
+            inputParams  = Sim.Param;
+            outputParams = SimCurveResults;
+
+            inputArr  = [inputParams.F  inputParams.kf  inputParams.R1f  inputParams.R1r inputParams.T2f];
+            outputArr = [outputParams.F outputParams.kf outputParams.R1f  outputParams.R1r outputParams.T2f];
+
+            %                                                 , # percent
+            %                                                 . [F  kf R1f R1r T2f]
+            testCase.verifyLessThan(pDiff(inputArr, outputArr), [30 30 30  30 30]);
+        end
+    end
+
+end
+
+function value = pDiff(inputVal, outputVal)
+    value = abs((outputVal-inputVal)./inputVal).*100;
+end


### PR DESCRIPTION
Commit d219623 moved around some files into new directories, and consequently the *.mat files loaded in by all SimDemo.m scripts have been broken since.

Changes made:

- Fixed the *.mat directory paths in each SimDemo.mat files
- Removed "clear" from the SimDemo.mat files to allow for testing
- Renamed each SimDemo file to unique filenames.
- Added Integration tests for each SimDemo_*.mat files
- Updated ReadMe.md to include the new test tags.