### PR TITLE
Add folder for external packages (e.g. NODDI) and install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,10 @@ SIRFSE/SimResults/SimCurveTempResults.mat
 SIRFSE/SimResults/SimRndTempResults.mat
 Data/SPGR_demo/flipdata.m
 MTSAT/interface.jpg
+
+# External Toolboxes
+External/*
+
+# Exceptions
+!.gitemptydir
+

--- a/External/.gitemptydir
+++ b/External/.gitemptydir
@@ -1,0 +1,1 @@
+# Empty file used to git commit empty directories

--- a/README.md
+++ b/README.md
@@ -6,16 +6,49 @@ qMRIlab is a powerful, open source, scalable, easy to use and intuitive software
 
 
 qMRILab is a fork from the initial project ['qMTLab'] (https://github.com/neuropoly/qMTLab):
-  For a quick introduction to qMTLab functionnalities, see the ['qMTLab presentation e-poster'] (https://github.com/neuropoly/qMTLab/raw/master/qMTLab-Presentation.ppsx), or alternatively you can view it on ['YouTube']
-                                                                                                                                                                                                              (https://youtu.be/WG0tVe-SFww).
-
+  For a quick introduction to qMTLab functionnalities, see the ['qMTLab presentation e-poster'] (https://github.com/neuropoly/qMTLab/raw/master/qMTLab-Presentation.ppsx), or alternatively you can view it on ['YouTube'](https://youtu.be/WG0tVe-SFww).
 
 The simulation part allows end users to easily simulate qMT data using the above described methods, evaluate how well these models perform under known parameters input, determine the most appropriate acquisition protocol and evaluate how fitting constraints impact the results. The data fitting part provides a simple interface to import real-world qMT data, fit them using the selected fitting procedure, and visualize the resulting parameters maps.
 
-Please view ['ReadMe.docx'](https://github.com/neuropoly/qMTLab/raw/master/ReadMe.docx) for details.
+Please view ['ReadMe.docx'](https://github.com/neuropoly/qMRILab/raw/master/ReadMe.docx) for details.
 
-Please report any bug or suggestions in [github](https://github.com/neuropoly/qMTLab/issues).
+Please report any bug or suggestions in [github](https://github.com/neuropoly/qMRILab/issues).
 
+## Dependencies
+
+* MATLAB_R2013a or later
+
+* [NODDI Matlab Toolbox v0.9 or later](https://www.nitrc.org/projects/noddi_toolbox/)
+
+## Installation
+
+After installation, we strongly recommend that you run all tests in this repository (see Test section below) to ensure correct installation and code compatibility with your operating system and MATLAB version.
+
+### Command-Line Instructions
+
+If you have git available on a command-line interface (e.g. Terminal on Mac OSX, Git Shell on Windows), the installation can be completed using a few quick commands.
+
+* In the command-line interface, navigate (`cd`) to the directory that you want to install qMTLab_Tab1s.
+
+* Clone the directory:
+
+`git clone https://github.com/neuropoly/qMRILab.git`
+
+* If you have NODDI already on installed, ensure that it is included in your default MATLAB path, or add it in startup.m.
+
+* If you don't have NODDI installed, download it [here](https://www.nitrc.org/projects/noddi_toolbox/) (signup required), and extract the file in the folder qMRILab/External/.
+
+* Open MATLAB, got to the qMTLab folder and run `startup`.
+
+* To start a qMRILab session, run `qMRILab`.
+
+### Zip Download Instructions
+
+The latest stable version of qMRILab can be downloaded freely [here](https://github.com/neuropoly/qMRILab/tarball/master).
+
+* Extract the downloaded file to the directory you want to install qMRILab.
+
+* Follow the instructions from the previous section from the NODDI point onward.
 
 ## Tests
 
@@ -41,22 +74,10 @@ and run the following command:
 
 `result = runTestSuite('Tag')`
 
-substituting `Tag` for one of the following test tags. If you develop new tests and give it a tag which isn't on this list,
+substituting `'Tag'` for one of the following test tags. If you develop new tests and give it a tag which isn't on this list,
 please update the README.md file accordingly.
 
-Current Test tags:
-
-* Unit
-
-* Integration
-
-* Demo
-
-* SPGR
-
-* bSSFP
-
-* SIRFSE
+Current Test tags: 'Unit', 'Integration', 'Demo', 'SPGR', 'bSSFP', 'SIRFSE'.
 
 ## Citation
 


### PR DESCRIPTION
I wasn't aware that a NODDI external MATLAB package was required since diffusion was added, since I've only used the MT-side of the software. The recently added popup warning informed me of such, but I think it would be helpful to inform the potential users in the README of the repo as well.

* Added dependencies of qMRILab in the README
* Added installation instructions of qMRILab in the README
* Added a folder called "External" so that users who don't have NODDI installed previously can install it in this location (that way the startup.m script will automatically add NODDI, instead of having to add it to your default path or by other means).